### PR TITLE
Make the Rmd files run on macOS

### DIFF
--- a/Rmd_files/AXX.Rmd
+++ b/Rmd_files/AXX.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "AXX"
-author: "Rico Kronenberg, Lisa Marie Oehlschl‰gel"
+author: "Rico Kronenberg, Lisa Marie Oehlschl√§gel"
 date: "3 Mai 2018"
 output: html_document
 ---

--- a/Rmd_files/B90V4.Rmd
+++ b/Rmd_files/B90V4.Rmd
@@ -31,7 +31,8 @@ Just replace the link "c:\\Users\\LM\\Documents\\BROOK90\\Documentation\\" with 
 
 ```{r chunkpath}
 projectpath<-"c:\\Users\\LM\\Documents\\BROOK90\\Documentation\\"
-output_html<-file.path(projectpath,"Documentation\\HTML_Files")
+projectpath<-"../../Brook90_R"
+output_html<-file.path(projectpath,"Documentation","HTML_Files")
 ```
 
 Then the script of the main programm MainProg.Rmd has to be rendered to run the script of B90V4.Rmd in R-Markdown.

--- a/Rmd_files/B90V4_sub.Rmd
+++ b/Rmd_files/B90V4_sub.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "B90V4_sub"
-author: "Rico Kronenberg, Lisa Marie Oehlschl‰gel"
+author: "Rico Kronenberg, Lisa Marie Oehlschl√§gel"
 date: "4 Mai 2018"
 output: html_document
 ---

--- a/Rmd_files/EVP.Rmd
+++ b/Rmd_files/EVP.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "EVP"
-author: "Rico Kronenberg, Lisa Marie Oehlschl‰gel"
+author: "Rico Kronenberg, Lisa Marie Oehlschl√§gel"
 date: "3 Mai 2018"
 output: html_document
 ---

--- a/Rmd_files/GLOBDECL.Rmd
+++ b/Rmd_files/GLOBDECL.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "GLOBLDECL"
-author: "Rico Kronenberg, Lisa Marie Oehlschl‰gel"
+author: "Rico Kronenberg, Lisa Marie Oehlschl√§gel"
 date: "3 Mai 2018"
 output: html_document
 ---

--- a/Rmd_files/KPT.Rmd
+++ b/Rmd_files/KPT.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "KPT"
-author: "Rico Kronenberg, Lisa Marie Oehlschlägel"
+author: "Rico Kronenberg, Lisa Marie OehlschlÃ¤gel"
 date: "29 April 2018"
 output: html_document
 ---
@@ -46,7 +46,7 @@ where b is a parameter and &Psi;s is the potential to which the curve extrapolat
 
 where Ks is the saturated hydraulic conductivity.
 
-With the assumption that &theta;r is usually so small it can be set to zero, these equations are usually attributed to [Campbell (1974)](./Literature.html). [Wösten and vanGenuchten (1988)](./Literature.html) state that &theta;r can be set to zero "without significantly affecting the accuracy of the results". The Campbell form (&theta;r = 0) is used in BROOK90 and by [Clapp and Hornberger (1978)](./Literature.html).
+With the assumption that &theta;r is usually so small it can be set to zero, these equations are usually attributed to [Campbell (1974)](./Literature.html). [WÃ¶sten and vanGenuchten (1988)](./Literature.html) state that &theta;r can be set to zero "without significantly affecting the accuracy of the results". The Campbell form (&theta;r = 0) is used in BROOK90 and by [Clapp and Hornberger (1978)](./Literature.html).
 
 Equation (2) fails as the soil approaches saturation, that is, as W approaches 1, because &Psi; at saturation must be 0, not &Psi;s. In this "near saturation region", [Clapp and Hornberger (1978)](./Literature.html) suggest that the parabolic expression
 

--- a/Rmd_files/Literature.Rmd
+++ b/Rmd_files/Literature.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Literature"
-author: "Rico Kronenberg, Lisa Marie Oehlschlägel"
+author: "Rico Kronenberg, Lisa Marie OehlschlÃ¤gel"
 date: "19 April 2018"
 output: html_document
 ---
@@ -79,9 +79,9 @@ output: html_document
 
 * Federer, C.A., D.E. Turcotte, and C.T. Smith. 1993. The organic fraction - bulk density relationship and the expression of nutrient content in forest soils. Can J For Res 23: 1026-1032
 
-* Federer, C.A., C. Vörösmarty, and B. Fekete. 1996. Intercomparison of methods for calculating potential evaporation in regional and global water balance models. Water Resour Res 32:2315-2321.
+* Federer, C.A., C. VÃ¶rÃ¶smarty, and B. Fekete. 1996. Intercomparison of methods for calculating potential evaporation in regional and global water balance models. Water Resour Res 32:2315-2321.
 
-* Federer, C.A., C. Vörösmarty, and B. Fekete. 2003. Sensitivity of annual evaporation to soil and root properties in two models of contrasting complexity. J Hydrometeorology 4:1276-1290.
+* Federer, C.A., C. VÃ¶rÃ¶smarty, and B. Fekete. 2003. Sensitivity of annual evaporation to soil and root properties in two models of contrasting complexity. J Hydrometeorology 4:1276-1290.
 
 * Fitzpatrick, E.A. and W.R. Stern. 1966. Estimates of potential evaporation using alternative data in Penman's formula. Agric Meteorol 3:225-239.
 
@@ -107,9 +107,9 @@ output: html_document
 
 * Klute, A. ed. 1986. Methods of Soil Analysis, Part 1. Am Soc Agron, Madison. 1188 p.
 
-* Körner, Ch., J.A. Scheel, and H. Bauer. 1979. Maximum leaf diffusive conductance in vascular plants. Photosynthetica 13:45-82.
+* KÃ¶rner, Ch., J.A. Scheel, and H. Bauer. 1979. Maximum leaf diffusive conductance in vascular plants. Photosynthetica 13:45-82.
 
-* Körner, Ch. 1994. Leaf diffusive conductances in the major vegetation types of the globe. In E.-D. Schulze and M.M. Caldwell, eds. Ecophysiology of photosynthesis. Springer Verlag, Berlin. p. 463-490.
+* KÃ¶rner, Ch. 1994. Leaf diffusive conductances in the major vegetation types of the globe. In E.-D. Schulze and M.M. Caldwell, eds. Ecophysiology of photosynthesis. Springer Verlag, Berlin. p. 463-490.
 
 * Leaf, C.F., and G.E. Brink. 1973. Hydrologic simulation model of Colorado subalpine forest. USDA For Serv Res Pap RM-107, 23 p.
 
@@ -169,7 +169,7 @@ output: html_document
 
 * Shuttleworth, W.J., and J.S. Wallace. 1985. Evaporation from sparse crops - an energy combination theory. Quart J Royal Meteorol Soc 111: 839-855.
 
-* Shuttleworth, W.J. 1991 Evaporation models in hydrology. In T.J. Schmugge and J. André, eds, Land surface evaporation, Springer, New York. pp 93-120.
+* Shuttleworth, W.J. 1991 Evaporation models in hydrology. In T.J. Schmugge and J. AndrÃ©, eds, Land surface evaporation, Springer, New York. pp 93-120.
 
 * Stewart, J.B. 1988. Modelling surface conductance of pine forest. Agric For Meteorol 43: 19-35.
 
@@ -193,7 +193,7 @@ output: html_document
 
 * van Genuchten, M.Th. 1980. A closed-form equation for predicting the hydraulic conductivity of unsaturated soils. Soil Sci Soc Am J 44: 892-898.
 
-* Vörösmarty, C.J., C.A. Federer, and A.L. Schloss. 1998. Potential evaporation functions compared on US watersheds: Possible implications for global-scale water balance and terrestrial ecosystem modeling. J Hydrol 207:147-169.
+* VÃ¶rÃ¶smarty, C.J., C.A. Federer, and A.L. Schloss. 1998. Potential evaporation functions compared on US watersheds: Possible implications for global-scale water balance and terrestrial ecosystem modeling. J Hydrol 207:147-169.
 
 * Wetzel, P.J. and J.T. Chang. 1987. Concerning the relationship between evapotranspiration and soil moisture. J Climate Appl Meteorol 26:18-27
 
@@ -201,6 +201,6 @@ output: html_document
 
 * Willmott, C.J. 1982. Some comments on the evaluation of model performance. Bull Am Meteorol Soc 63:1309-1313.
 
-* Wösten, J.H.M. and M. Th. van Genuchten. 1988. Using texture and other soil properties to predict the unsaturated soil hydraulic functions. Soil Sci Soc Am J 52:1762-1770.
+* WÃ¶sten, J.H.M. and M. Th. van Genuchten. 1988. Using texture and other soil properties to predict the unsaturated soil hydraulic functions. Soil Sci Soc Am J 52:1762-1770.
 
 * Yates, S.R., M.Th. van Genuchten, A.W. Warrick, and F.J. Leij. 1992. Analysis of measured, predicted, and estimated hydraulic conductvity using the RETC computer program. Soil Sci Soc Am J 56: 347-354. 

--- a/Rmd_files/MainProg.Rmd
+++ b/Rmd_files/MainProg.Rmd
@@ -50,26 +50,26 @@ It is important to define your "projectpath" to upload the necessary scripts inc
 Running the Rmd-files causes that html-files of the included scripts will be produced. To store them in another directory as the Rmd-files it is defined where they will be saved ("output_html"). 
 
 ```{r chunk3, message=FALSE, results='hide'}
-projectpath<-"c:\\Users\\LM\\Documents\\BROOK90\\Documentation\\"
-output_html<-file.path(projectpath,"Documentation\\HTML_Files")
+projectpath<-"../../Brook90_R"
+output_html<-file.path(projectpath,"Documentation","HTML_Files")
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'GLOBDECL.Rmd'),output_dir=output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'GLOBDECL.Rmd'),output_dir=output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'AXX.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'AXX.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'KPT.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'KPT.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'EVP.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'EVP.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'PET.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'PET.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'SUN.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'SUN.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'WAT.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'WAT.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'SNO.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'SNO.Rmd'),output_dir = output_html)
 
-rmarkdown::render(file.path(projectpath,"Rmd_files\\",'B90V4_sub.Rmd'),output_dir = output_html)
+rmarkdown::render(file.path(projectpath,"Rmd_files",'B90V4_sub.Rmd'),output_dir = output_html)
 ```
 
 The following table shows the description of the scriptnames:
@@ -107,10 +107,10 @@ If you use your own meteorological or precipitation file, make sure that your fi
 The input data (meteorological data, precipitation data, catchment parameters) are located in a different folder ("Input_data").
 
 ```{r chunk4}
-meteoFile <-read.table(file.path(projectpath,"Input_data\\","data_input_WB_1999_point.txt"))
+meteoFile <-read.table(file.path(projectpath,"Input_data","data_input_WB_1999_point.txt"))
 MData<-matrix(meteoFile)
 
-precFile <-read.table(file.path(projectpath,"Input_data\\","P_WBG_0060_Minuten_1999_point.txt"))
+precFile <-read.table(file.path(projectpath,"Input_data","P_WBG_0060_Minuten_1999_point.txt"))
 MhhData<-matrix(precFile)
 ```
 
@@ -121,7 +121,7 @@ The canopy-file includes 18 parameters and the root density (ROOTDEN), with 25 p
 If changes need to be done, change them in the textfile "canopy.txt" or use your on file with the same formatting.
 
 ```{r chunk5, warning=FALSE}
-canopy_file <- read.table(file.path(projectpath,"Input_data\\","canopy.txt"), header = FALSE, fill=TRUE , dec = "." , sep = ",", strip.white = TRUE)
+canopy_file <- read.table(file.path(projectpath,"Input_data","canopy.txt"), header = FALSE, fill=TRUE , dec = "." , sep = ",", strip.white = TRUE)
 
 #canopy parameters
 canopy_varname <- as.character(canopy_file[,1])
@@ -164,7 +164,7 @@ rm(roota,rootb,rootc,rootd,roote,rootf,rootaa,rootbb,rootcc,root_a,rootdd,rootee
 This file contains 43 parameters that can be changed in the textfile.
 
 ```{r chunk6}
-fixed_file <-read.table(file.path(projectpath,"Input_data\\","fixed.txt"), header = FALSE, fill=TRUE, sep = "," , dec = "." , row.names = 1)
+fixed_file <-read.table(file.path(projectpath,"Input_data","fixed.txt"), header = FALSE, fill=TRUE, sep = "," , dec = "." , row.names = 1)
 
 fixed_varname <- rownames(fixed_file)
 fixed_varvalue <- fixed_file [,c(1)]
@@ -185,7 +185,7 @@ rm(fixed_varname,fixed_varvalue,quant_fixed)
 Different flow parameters are included in this file. All 13 values can be changed if it is necessary.
 
 ```{r chunk7}
-flow_file <-read.table(file.path(projectpath,"Input_data\\","flow_standard.txt"), header = FALSE, fill=TRUE, sep = "," , dec = "." , row.names = 1)
+flow_file <-read.table(file.path(projectpath,"Input_data","flow_standard.txt"), header = FALSE, fill=TRUE, sep = "," , dec = "." , row.names = 1)
 
 flow_varname <- rownames(flow_file)
 flow_varvalue <- flow_file [,c(1)]
@@ -206,7 +206,7 @@ rm(flow_varname,flow_varvalue,quant_flow)
 The initial file contains 4 parameters and PSIMIN, the initial matric soil water potential for layer, with 25 layers.
 
 ```{r chunk8}
-initial_file <-read.table(file.path(projectpath,"Input_data\\","initial.txt"),header = FALSE,fill=TRUE,sep = ",",dec = ".",row.names = 1)
+initial_file <-read.table(file.path(projectpath,"Input_data","initial.txt"),header = FALSE,fill=TRUE,sep = ",",dec = ".",row.names = 1)
 
 initial_varname <- rownames(initial_file)
 initial_varvalue <- as.character(initial_file [,1])
@@ -229,7 +229,7 @@ rm(initial_varname,initial_varvalue,quant_initial)
 The location-file has a little bit more complicated structure, 5 parameters at the beginning, the average duration of daily precip by month (DURATN), ten pairs of DOY and relative canopy height (RELHT) and ten pairs of DOY and relative LAI (RELLAI). But they can be easily changed in the file.
 
 ```{r chunk9}
-location_file <-read.table(file.path(projectpath,"Input_data\\","location.txt"), header = FALSE, fill=TRUE, sep = "," , dec = ".", strip.white = TRUE)
+location_file <-read.table(file.path(projectpath,"Input_data","location.txt"), header = FALSE, fill=TRUE, sep = "," , dec = ".", strip.white = TRUE)
 
 location_varname <- as.character(location_file[,1])
 location_varvalue <- as.character(location_file [,2])
@@ -297,7 +297,7 @@ In this file the number of layers (NLAYER) can be changed and eight other soil p
 * WETINF - wetness at dry end of near-saturation range
 
 ```{r chunk10}
-soil_file <-read.table(file.path(projectpath,"Input_data\\","soil.txt"), header = FALSE, fill=TRUE , dec = "." , sep = "", strip.white = TRUE)
+soil_file <-read.table(file.path(projectpath,"Input_data","soil.txt"), header = FALSE, fill=TRUE , dec = "." , sep = "", strip.white = TRUE)
 
 soil_var1 <- as.character(soil_file[,1])
 soil_var2 <- as.character(soil_file[,2])

--- a/Rmd_files/PET.Rmd
+++ b/Rmd_files/PET.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "PET"
-author: "Rico Kronenberg, Lisa Marie Oehlschlägel"
+author: "Rico Kronenberg, Lisa Marie OehlschlÃ¤gel"
 date: "29 April 2018"
 output: html_document
 ---
@@ -145,7 +145,7 @@ return(c(HEIGHT, LAI, SAI, RTLEN, RPLANT))
 ```
 
 ### Function ESAT
-The subroutine ESAT calculates the saturated vapor pressure (kPa) e*, from temperature (°C) T, and calculates &Delta;. The equations of [Murray (1967)](./Literature.Rmd) are used.
+The subroutine ESAT calculates the saturated vapor pressure (kPa) e*, from temperature (Â°C) T, and calculates &Delta;. The equations of [Murray (1967)](./Literature.Rmd) are used.
 
 The input to ESAT is:
 

--- a/Rmd_files/SNO.Rmd
+++ b/Rmd_files/SNO.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "SNO"
-author: "Rico Kronenberg, Lisa Marie Oehlschlägel"
+author: "Rico Kronenberg, Lisa Marie OehlschlÃ¤gel"
 date: "24 April 2018"
 output: html_document
 ---
@@ -18,11 +18,11 @@ BROOK90 therefore falls back on the classic degree-day method for estimating sno
 
 A modified degree-day method that incorporates solar radiation and wind speed could be added but would require development for sparse canopies. Another improvement would separate the day into daytime and nighttime as is done in BROOK90 for evaporation. But BROOK90 currently uses only the mean daily temperature (TA) for the snow energy balance.
 
-The "water equivalent" of snow (SNOW, mm) is the depth of water a snowpack would produce if it were all melted; this is the BROOK90 variable that represents the snowpack. The actual depth of snow, assuming a constant snow density (SNODEN), is used only to calculate the amount of the canopy above the snow in subroutine CANOPY. Variable snow density (mass per unit volume) is not simulated in BROOK90. When the snow is colder than 0°C, it has a "cold content" (CC, MJ/m2), which is the energy needed to warm the snow to 0°C. When the snow is at 0°C, part of SNOW can be liquid water (SNOWLQ, mm). The maximum liquid water that can be retained by the snowpack without draining is a constant fraction (MAXLQF) of SNOW; CC and SNOWLQ are always initialized as zero in BROOK90, so any initial SNOW is considered to be at 0°C with no liquid water.
+The "water equivalent" of snow (SNOW, mm) is the depth of water a snowpack would produce if it were all melted; this is the BROOK90 variable that represents the snowpack. The actual depth of snow, assuming a constant snow density (SNODEN), is used only to calculate the amount of the canopy above the snow in subroutine CANOPY. Variable snow density (mass per unit volume) is not simulated in BROOK90. When the snow is colder than 0Â°C, it has a "cold content" (CC, MJ/m2), which is the energy needed to warm the snow to 0Â°C. When the snow is at 0Â°C, part of SNOW can be liquid water (SNOWLQ, mm). The maximum liquid water that can be retained by the snowpack without draining is a constant fraction (MAXLQF) of SNOW; CC and SNOWLQ are always initialized as zero in BROOK90, so any initial SNOW is considered to be at 0Â°C with no liquid water.
 
 Groundmelt is snowmelt at the bottom of a snowpack; it occurs because of heat conduction from the soil whenever the soil is unfrozen. A constant groundmelt rate (GRDMLT, mm/d) is an constant parameter in BROOK90 and is applied whenever there is snow on the ground. The possibilities of frozen soil or variable groundmelt are not considered.
 
-Snowmelt (SMLT, mm/d) is the sum of groundmelt and drainage of excess liquid water from the snowpack. Drainage occurs only after the snowpack is both isothermal at 0°C and is holding the maximum possible liquid water; the snowpack is then "ripe". The gains and losses of liquid water by the snowpack, including the refreezing of rain on cold snow, are handled in the somewhat complicated subroutine SNOWPACK.
+Snowmelt (SMLT, mm/d) is the sum of groundmelt and drainage of excess liquid water from the snowpack. Drainage occurs only after the snowpack is both isothermal at 0Â°C and is holding the maximum possible liquid water; the snowpack is then "ripe". The gains and losses of liquid water by the snowpack, including the refreezing of rain on cold snow, are handled in the somewhat complicated subroutine SNOWPACK.
 
 BROOK90 assumes that the snowpack is always isothermal. In reality, large and variable temperature gradients can exist in thick snowpacks; simulating these is beyond the scope of BROOK90. The snowpack temperature (TSNOW) at the beginning of the day is calculated in MSBSETVARS from the cold content
 
@@ -40,17 +40,17 @@ where CVICE is the heat capacity of ice (0.00192 MJ m-2 mm-1 K-1) ([Leavesley an
 ### Function SNOENRGY
 The energy flux density to the snow surface (SNOEN, MJ m-2 d-1) is calculated in subroutine SNOENRGY independently of precipitation for the day.
 
-When TA is <= 0°C, SNOEN is the energy used to heat or cool the snowpack
+When TA is <= 0Â°C, SNOEN is the energy used to heat or cool the snowpack
 
 * SNOEN = CCFAC x 2 x DAYLEN x (TA - TSNOW)
 
-where CCFAC is an input parameter, and DAYLEN is the daytime fraction of a day. CCFAC is the below-zero degree-day factor for a day with a daylength of 0.5 d. [Anderson, 1973](./Literature.Rmd) pointed out that this degree-day factor appears to vary seasonally. In BROOK90, this seasonality is incorporated by using 2 * DAYLEN as a multiplier in the above equation. BROOK90 is not very sensitive to CCFAC unless it is close to 0; larger values of CCFAC make the snow melt later because the snowpack cools more. When CCFAC = 0, snow temperature is always 0°C and there is never any cold content.
+where CCFAC is an input parameter, and DAYLEN is the daytime fraction of a day. CCFAC is the below-zero degree-day factor for a day with a daylength of 0.5 d. [Anderson, 1973](./Literature.Rmd) pointed out that this degree-day factor appears to vary seasonally. In BROOK90, this seasonality is incorporated by using 2 * DAYLEN as a multiplier in the above equation. BROOK90 is not very sensitive to CCFAC unless it is close to 0; larger values of CCFAC make the snow melt later because the snowpack cools more. When CCFAC = 0, snow temperature is always 0Â°C and there is never any cold content.
 
-When TA is greater than 0°C, energy is provided that can melt snow, and SNOEN is calculated differently. The energy supply rate, SNOEN, is then
+When TA is greater than 0Â°C, energy is provided that can melt snow, and SNOEN is calculated differently. The energy supply rate, SNOEN, is then
 
 * SNOEN = MELFAC x 2 x DAYLEN x SLFDAY x TA x exp(-LAIMLT x LAI - SAIMLT x SAI)
 
-where MELFAC is the melting degree-day factor for a day with a daylength of 0.5 d and no canopy, SLFDAY is the ratio of potential insolation on the slope to that on a horizontal surface, and the input parameters LAIMLT and SAIMLT express the dependence of SNOEN on leaf area index (LAI) and stem area index (SAI). MELFAC uses 0°C as a base and is zero for TA below this. Inclusion of SLFDAY in the MELT equation arises from an assumption that radiation melt plays an important role. If this is not so, then SLFDAY multiplier could be omitted, and snowmelt would not depend on slope-aspect. The functional forms of the SAI and LAI dependencies are based on the somewhat arbitrary curves used by [Federer and Lash (1978)](./Literature.Rmd).
+where MELFAC is the melting degree-day factor for a day with a daylength of 0.5 d and no canopy, SLFDAY is the ratio of potential insolation on the slope to that on a horizontal surface, and the input parameters LAIMLT and SAIMLT express the dependence of SNOEN on leaf area index (LAI) and stem area index (SAI). MELFAC uses 0Â°C as a base and is zero for TA below this. Inclusion of SLFDAY in the MELT equation arises from an assumption that radiation melt plays an important role. If this is not so, then SLFDAY multiplier could be omitted, and snowmelt would not depend on slope-aspect. The functional forms of the SAI and LAI dependencies are based on the somewhat arbitrary curves used by [Federer and Lash (1978)](./Literature.Rmd).
 
 The following table includes the input to this function:
 
@@ -87,7 +87,7 @@ Separation of daily precipitation into snow or rain is a major problem in hydrol
 
 * SNOFRC = (RSTEMP - TMIN) / (TMAX - TMIN)
 
-where RSTEMP is the "base" temperature for the rain-snow transition. When TMAX < RSTEMP, SNOFRC = 1; when TMIN > RSTEMP, SNOFRC = 0. The default value of RSTEMP is -0.5°C because that seems to work best at Hubbard Brook. If precipitation is input more than once a day, the same SNOFRC is used for all precipitation intervals. 
+where RSTEMP is the "base" temperature for the rain-snow transition. When TMAX < RSTEMP, SNOFRC = 1; when TMIN > RSTEMP, SNOFRC = 0. The default value of RSTEMP is -0.5Â°C because that seems to work best at Hubbard Brook. If precipitation is input more than once a day, the same SNOFRC is used for all precipitation intervals. 
 
 The subroutine SNOFRAC separetes rainfall from snowfall. The input includes:
 
@@ -95,7 +95,7 @@ Input |Description
 ------|-----------------------
 TMAX  |maximum temperature for the day (degC)
 TMIN  |minimum temperature for the day (degC)
-RSTEMP|base temperature for snow-rain transition, -0.5°C (degC)
+RSTEMP|base temperature for snow-rain transition, -0.5Â°C (degC)
 
 The output of SNOFRAC is:
 
@@ -119,7 +119,7 @@ Evaporation rate from the snowpack, and its negative, condensation, are evaluate
 
 * E = (cp &rho; / g Ls rw ) (e0 - ea) / (raa + ras)
 
-where ea is the vapor pressure of the air, e0 is the surface vapor pressure, and raa and ras are the Shuttleworth-Wallace resistances described in section [PET](./PET.Rmd). The constants cp &rho; (CPRHO), &gamma; (GAMMA), and the latent heat of sublimation Ls &rho;w (LS) are constant. BROOK90 assumes that the snowpack is always isothermal and that its temperature does not change diurnally. When the snowpack temperature (TSNOW) is less than 0°C, the surface vapor pressure, e0, is the saturated vapor pressure at TSNOW and is obtained by calling subroutine [ESAT](./PET.Rmd). When TSNOW is 0°C, e0 is 0.61 kPa; use of Ls instead of the latent heat of vaporization, Lv, in this case is slightly wrong. The vapor pressure ea (EA) is the input vapor pressure at reference height za . The resistances raa and ras are obtained from subroutine [SWGRA](./PET.Rmd) using the daily average wind speed (UA). The value of E in mm/d returned from SNOVAP is called PSNVP because it can be reduced in [Function SNOWPACK](#function-snowpack) if snow disappears.
+where ea is the vapor pressure of the air, e0 is the surface vapor pressure, and raa and ras are the Shuttleworth-Wallace resistances described in section [PET](./PET.Rmd). The constants cp &rho; (CPRHO), &gamma; (GAMMA), and the latent heat of sublimation Ls &rho;w (LS) are constant. BROOK90 assumes that the snowpack is always isothermal and that its temperature does not change diurnally. When the snowpack temperature (TSNOW) is less than 0Â°C, the surface vapor pressure, e0, is the saturated vapor pressure at TSNOW and is obtained by calling subroutine [ESAT](./PET.Rmd). When TSNOW is 0Â°C, e0 is 0.61 kPa; use of Ls instead of the latent heat of vaporization, Lv, in this case is slightly wrong. The vapor pressure ea (EA) is the input vapor pressure at reference height za . The resistances raa and ras are obtained from subroutine [SWGRA](./PET.Rmd) using the daily average wind speed (UA). The value of E in mm/d returned from SNOVAP is called PSNVP because it can be reduced in [Function SNOWPACK](#function-snowpack) if snow disappears.
 
 For evaporation from snow in the open, [U.S. Army Corps of Engineers (1956)](./Literature.Rmd) gives
 
@@ -199,7 +199,7 @@ return(PSNVP)
 ### Function SNOWPACK
 In each precipitation interval, throughfall of rain (RTHR) and throughfall of snow (STHR) are calculated and subroutine SNOWPACK is entered if there is STHR or if there is SNOW. This subroutine adds throughfall to the snowpack, subtracts groundmelt, snow evaporation, and drainage of liquid water, and calculates the new cold content (CC) and liquid water content (SNOWLQ) of the snowpack. There are a number of different ways to program all this adding and subtracting of energy and water. The program flow of SNOWPACK has been selected to make the many realizable situations as clear as possible. Much shorter algorithms could have been used, but at the expense of clarity. Any alterations to this routine must be made carefully, keeping all the possibilities in mind. However, unlike routine SNOENRGY, the content of the SNOWPACK routine is essentially standard for all snow models and alterations generally should not be necessary.
 
-In SNOWPACK, snow throughfall (STHR) is first added to SNOW. If TA is <0°C, the cold content of the new snow is increased by
+In SNOWPACK, snow throughfall (STHR) is first added to SNOW. If TA is <0Â°C, the cold content of the new snow is increased by
 
 * CC = CC - CVICE x TA x STHR x DTP
 
@@ -215,7 +215,7 @@ The amount of snowpack warming or cooling is calculated next. The equivalent amo
 
 * EQEN = DTP x (SNOEN + RTHR x RMAX(TA,0) x CVLQ) / LF
 
-where CVLQ is the specific heat of water, and LF is the latent heat of fusion of water. Both CVLQ and LF are constant. When EQEN is less than 0, the snow is cooling; first any SNOWLQ is refrozen, then CC is increased. CC is not allowed to be reduced so that TSNOW is below the mean daily air temperature, TA, although it may remain colder, i.e. if TA < 0°, CC can only be reduced to TSNOW = TA. When EQEN is greater than 0, the snow is warming; first CC is reduced, then SNOWLQ is produced, and finally melt (SMLT) occurs.
+where CVLQ is the specific heat of water, and LF is the latent heat of fusion of water. Both CVLQ and LF are constant. When EQEN is less than 0, the snow is cooling; first any SNOWLQ is refrozen, then CC is increased. CC is not allowed to be reduced so that TSNOW is below the mean daily air temperature, TA, although it may remain colder, i.e. if TA < 0Â°, CC can only be reduced to TSNOW = TA. When EQEN is greater than 0, the snow is warming; first CC is reduced, then SNOWLQ is produced, and finally melt (SMLT) occurs.
 
 Finally, any rain throughfall (RTHR) is added to the snowpack. If any CC exists it refreezes rain until the CC is "used up". Any additional rain then increases SNOWLQ; when the maximum SNOWLQ is reached, the input of rain to the snow (RSNO) has also reached its maximum. In all cases the final results are a new SNOW, new SNOLQ and CC, and a value of RSNO.
 

--- a/Rmd_files/SUN.Rmd
+++ b/Rmd_files/SUN.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "SUN"
-author: "Rico Kronenberg, Lisa Marie Oehlschlägel"
+author: "Rico Kronenberg, Lisa Marie OehlschlÃ¤gel"
 date: "17 April 2018"
 output: html_document
 ---
@@ -141,7 +141,7 @@ SUNDS requires the solar constant (SCD), which is the radiation (W/m2) on a surf
 
 where SC is the solar constant at the mean earth-sun distance ([Swift (1976)](./Literature.Rmd)). SC is set to 1367 W/m2 ([Lean (1991)](./Literature.Rmd)) and can not be changed.
 
-The declination of the sun (DEC) is the angle by which the sun is above or below the plane of the earth's equator. DEC is zero at the equinoxes and +23.5° or -23.5 at the solstices. [Swift (1976)](./Literature.Rmd) gives the solar declination (radians) as:
+The declination of the sun (DEC) is the angle by which the sun is above or below the plane of the earth's equator. DEC is zero at the equinoxes and +23.5Â° or -23.5 at the solstices. [Swift (1976)](./Literature.Rmd) gives the solar declination (radians) as:
 
 * DEC = ASIN {0.39785 x SIN [4.86961 + 0.017203 x DOY + 0.033446 x SIN (6.224111 + 0.017202 x DOY)]}
 
@@ -167,7 +167,7 @@ Name  |Description
 ------|------------------------------------------------------------
 I0SDAY|potential insolation on slope, map area basis (MJ/m2)
 SCD   |solar constant for day (W/m2)
-DEC   |declination of the sun (radians), zero at the equinoxes, +23.5° / -23.5 at the solstices
+DEC   |declination of the sun (radians), zero at the equinoxes, +23.5Â° / -23.5 at the solstices
 TWORIS|if two sunrises on slope
 Temp  |temporary variable
 T0    |hour angle of sunrise on horizontal (radians)

--- a/Rmd_files/WAT.Rmd
+++ b/Rmd_files/WAT.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "WAT"
-author: "Rico Kronenberg, Lisa Marie Oehlschl‰gel"
+author: "Rico Kronenberg, Lisa Marie Oehlschl√§gel"
 date: "19 April 2018"
 output: html_document
 ---

--- a/Rmd_files/consistency_meteoFile.Rmd
+++ b/Rmd_files/consistency_meteoFile.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Function Datacheck"
-author: "Lisa Marie Oehlschl‰gel"
+author: "Lisa Marie Oehlschl√§gel"
 date: "12 April 2018"
 output: html_document
 ---


### PR DESCRIPTION
Running the `B90V4.Rmd` file on macOS 10.14.6 with `rmarkdown 2.3` resulted in corrupt HTML files containing only the `RMarkdown` header without the actual content.

Reformatting the `*.Rmd`-files in UTF-8 and some modifications to the file paths (namely removing the trailing `\\`) make the files run correctly on my system.

I couldn't test the code on a Windows machine, but I don't expect the changes to be breaking. But this should be tested. 